### PR TITLE
Remove useless line about massdns

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -133,7 +133,6 @@ else
   git clone --quiet https://github.com/blechschmidt/massdns build-massdns
   cd build-massdns
   make 2>&1 >/dev/null
-  cp bin/massdns /usr/local/bin/ 2>&1 >/dev/null
   cp bin/massdns $BINARIES_PATH/massdns 2>&1 >/dev/null
   rm -rf build-massdns/.git
 fi


### PR DESCRIPTION
@j3ssie Removed useless line. `massdns` will be already copied in binary directory of osmedeus. There is no need to copy massdns also on `/usr/local/bin` folder (that still requires SUDO).